### PR TITLE
Fixed bug causing legends to print first 3 items only

### DIFF
--- a/ggplot/scales/scale_colour_brewer.py
+++ b/ggplot/scales/scale_colour_brewer.py
@@ -61,7 +61,8 @@ class scale_colour_brewer(scale):
 
         # Try to get colors
         try:
-            color_col = gg.aesthetics.get('color', gg.aesthetics['fill'])
+            fill_col = gg.aesthetics.get('fill', None)
+            color_col = gg.aesthetics.get('color', fill_col)
             n_colors = max(gg.data[color_col].nunique(),3)
         except KeyError :
             # If we are neither using 'color' nor 'fill' then assume there is


### PR DESCRIPTION
When using scale_colour_brewer legends would consists only of the first
3 items because of the evaluation order of a python get statement.

The code ```a.get('color', a['fill'])``` would throw a ```KeyError```
when the key `fill` wasn't present even when `color` was present and
there wasn't any reason to evaluate the second argument of `get` per se.

I'm to blame for this bug myself.