### PR TITLE
fix legend not being displayed due to wrong axes reference

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -420,7 +420,7 @@ class ggplot(object):
             # getting set to True.
             if self.legend:
                 # works with faceted and non-faceted plots
-                ax = axs[0][self.n_rows - 1]
+                ax = plt.gcf().axes[self.n_rows - 1]
                 box = ax.get_position()
                 ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
                 add_legend(self.legend, ax)


### PR DESCRIPTION
Over here legend was not being displayed. Debugging the behaviour showed me, that the references to the axes seemed to be different. The legend box was added correctly to the `ax` object in the `if self.legend:` block, but the `ax = axs[0][self.n_rows - 1]` object seemed to be different from the `for ax in plt.gcf().axes` references (both `plt.gcf().axes` and `axs` had only one element).

One was printed as `Axes(0.125,0.1;0.62x0.8)`, the other was printed as `Axes(0.125,0.1;0.775x0.8)`. So the reference seemed to be different, the legend was added to the wrong element.

The line replacement from the pull request works on my PC (but I do not know if it has any side effects on other visualizations!).