### PR TITLE
Issue #428 - Pandas API has changed

### DIFF
--- a/ggplot/stats/stat_bin.py
+++ b/ggplot/stats/stat_bin.py
@@ -124,7 +124,7 @@ class stat_bin(stat):
                             'weights': weights
                             })
         _wfreq_table = pd.pivot_table(_df, values='weights',
-                                      rows=['assignments'], aggfunc=np.sum)
+                                      index=['assignments'], aggfunc=np.sum)
 
         # For numerical x values, empty bins get have no value
         # in the computed frequency table. We need to add the zeros and

--- a/ggplot/stats/stat_bin2d.py
+++ b/ggplot/stats/stat_bin2d.py
@@ -46,7 +46,7 @@ class stat_bin2d(stat):
                            'ybin': y_assignments,
                            'weights': weight})
         table = pd.pivot_table(df, values='weights',
-                               rows=['xbin', 'ybin'], aggfunc=np.sum)
+                               index=['xbin', 'ybin'], aggfunc=np.sum)
         rects = np.array([[xbreaks[i], xbreaks[i+1],
                            ybreaks[j], ybreaks[j+1],
                            table[(i, j)]]


### PR DESCRIPTION
Fixes Issue #428.  As of about Pandas 16.0, the API for pivot_tables has changed.  The keyword arguments 'rows' and 'cols' have changed to 'index' and 'columns'