### PR TITLE
Changed pd.pivot_table call to use index keyword

### DIFF
--- a/ggplot/stats/stat_bin.py
+++ b/ggplot/stats/stat_bin.py
@@ -124,7 +124,7 @@ class stat_bin(stat):
                             'weights': weights
                             })
         _wfreq_table = pd.pivot_table(_df, values='weights',
-                                      rows=['assignments'], aggfunc=np.sum)
+                                      index=['assignments'], aggfunc=np.sum)
 
         # For numerical x values, empty bins get have no value
         # in the computed frequency table. We need to add the zeros and


### PR DESCRIPTION
This is a (very very easy) fix for [Issue 428](https://github.com/yhat/ggplot/issues/428) which states that the pandas API has changed.

But it's just the name of the keyword command which has changed from `rows` to `index` for consistency with the `pivot()` function.