### PR TITLE
making figure an attribute of the class

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -97,6 +97,7 @@ class ggplot(object):
         self.legend = None
         # coords
         self.coord_equal = None
+        self.figure = None
 
         # default theme is theme_gray
         self.theme = theme_gray()
@@ -428,7 +429,7 @@ class ggplot(object):
             # Finaly apply any post plot callbacks (theming, etc)
             for ax in plt.gcf().axes:
                 self.theme.post_plot_callback(ax)
-
+            self.figure = fig
         return plt.gcf()
 
     def _make_plot_data(self, data=None, aes=None):


### PR DESCRIPTION
I believe this modification can make easy to access to the matplotlib figurecanvas when embeding different figures in an app is required. http://matplotlib.org/examples/user_interfaces/embedding_in_gtk3.html .

p = ggplot(mtcars, aes('cyl'))
p.draw()
print("figurecanvas", p.figure.canvas)

p.figure.canvas can be added as a widget depending on the backend being used.