### PR TITLE
Use "is" instead of  "==" for numpy array comparison

### DIFF
--- a/ggplot/geoms/geom_bar.py
+++ b/ggplot/geoms/geom_bar.py
@@ -44,7 +44,7 @@ class geom_bar(geom):
 
         # Make sure bottom is initialized and get heights. If we are working on
         # a new plot (using facet_wrap or grid), then reset bottom
-        _reset = self.bottom == None or (self.ax != None and self.ax != ax)
+        _reset = self.bottom is None or (self.ax != None and self.ax != ax)
         self.bottom = np.zeros(len(x)) if _reset else self.bottom
         self.ax = ax
         heights = np.array(pinfo.pop('y'))


### PR DESCRIPTION
numpy will be using "==" for elementwise comparisons in the future for numpy arrays. As as a consequence the following warning pops up when creating a plot with this class:

FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.

Changing "==" to "is" for this case.

