### PR TITLE
Use axes.prop_cycle

### DIFF
--- a/ggplot/components/palettes.py
+++ b/ggplot/components/palettes.py
@@ -132,7 +132,7 @@ def color_palette(name=None, n_colors=6, desat=None):
     )
 
     if name is None:
-        palette = mpl.rcParams["axes.color_cycle"]
+        palette = mpl.rcParams["axes.prop_cycle"]
     elif not isinstance(name, string_types):
         palette = name
     elif name == "hls":

--- a/ggplot/geoms/geom_point.py
+++ b/ggplot/geoms/geom_point.py
@@ -24,9 +24,9 @@ class geom_point(geom):
             pinfo['facecolor'] = ''
 
         # for some reason, scatter doesn't default to the same color styles
-        # as the axes.color_cycle
+        # as the axes.prop_cycle
         if "color" not in pinfo and self.params['cmap'] is None:
-            pinfo["color"] = mpl.rcParams.get("axes.color_cycle", ["#333333"])[0]
+            pinfo["color"] = mpl.rcParams.get("axes.prop_cycle", ["#333333"])[0]
 
         if self.params['position'] == 'jitter':
             pinfo['x'] *= np.random.uniform(.9, 1.1, len(pinfo['x']))

--- a/ggplot/geoms/geom_pointrange.py
+++ b/ggplot/geoms/geom_pointrange.py
@@ -124,9 +124,9 @@ class geom_pointrange(geom):
             pinfopoint['facecolor'] = ''
 
         # for some reason, scatter doesn't default to the same color styles
-        # as the axes.color_cycle
+        # as the axes.prop_cycle
         if "color" not in pinfopoint and self.params['cmap'] is None:
-            pinfopoint["color"] = mpl.rcParams.get("axes.color_cycle", ["#333333"])[0]
+            pinfopoint["color"] = mpl.rcParams.get("axes.prop_cycle", ["#333333"])[0]
 
         pinfopoint['s'] = pinfopoint.pop('linewidth')**2*4
 

--- a/ggplot/themes/theme_538.py
+++ b/ggplot/themes/theme_538.py
@@ -20,7 +20,7 @@ class theme_538(theme):
         self._rcParams["examples.download"] = "True"
         self._rcParams["patch.linewidth"] = "0.5"
         self._rcParams["legend.fancybox"] = "True"
-        self._rcParams["axes.color_cycle"] = [ "#30a2da", "#fc4f30", "#e5ae38",
+        self._rcParams["axes.prop_cycle"] = [ "#30a2da", "#fc4f30", "#e5ae38",
                                                "#6d904f", "#8b8b8b"]
         self._rcParams["axes.facecolor"] = "#f0f0f0"
         self._rcParams["axes.labelsize"] = "large"

--- a/ggplot/themes/theme_gray.py
+++ b/ggplot/themes/theme_gray.py
@@ -36,7 +36,7 @@ class theme_gray(theme):
         self._rcParams["axes.labelsize"] = "large"
         self._rcParams["axes.labelcolor"] = "black"
         self._rcParams["axes.axisbelow"] = "True"
-        self._rcParams["axes.color_cycle"] = ["#333333", "348ABD", "7A68A6",
+        self._rcParams["axes.prop_cycle"] = ["#333333", "348ABD", "7A68A6",
                                              "A60628",
                                              "467821", "CF4457", "188487",
                                              "E24A33"]

--- a/ggplot/themes/theme_seaborn.py
+++ b/ggplot/themes/theme_seaborn.py
@@ -172,7 +172,7 @@ class theme_seaborn(theme):
         # rcParams["axes.labelsize"] = "large"
         # rcParams["axes.labelcolor"] = "black"
         # rcParams["axes.axisbelow"] = "True"
-        rcParams["axes.color_cycle"] = ["#333333", "348ABD", "7A68A6", "A60628",
+        rcParams["axes.prop_cycle"] = ["#333333", "348ABD", "7A68A6", "A60628",
                 "467821", "CF4457", "188487", "E24A33"]
         # rcParams["grid.color"] = "white"
         # rcParams["grid.linewidth"] = "1.4"


### PR DESCRIPTION
`axes.color_cycle` was deprecated in matplotlib 1.5:

> ### Added `axes.prop_cycle` key to rcParams
> This is a more generic form of the now-deprecated `axes.color_cycle param`. Now, we can cycle more than just colors, but also linestyles, hatches, and just about any other artist property. Cycler notation is used for defining property cycles. Adding cyclers together will be like you are zip()-ing together two or more property cycles together:

http://matplotlib.org/users/whats_new.html?highlight=prop_cycle#added-axes-prop-cycle-key-to-rcparams