### PR TITLE
Timezone optional argument in date_format.py

### DIFF
--- a/ggplot/utils/date_format.py
+++ b/ggplot/utils/date_format.py
@@ -1,14 +1,15 @@
 from matplotlib.dates import DateFormatter
 
-def date_format(format='%Y-%m-%d'):
+def date_format(format='%Y-%m-%d',tz=None):
     """
     "Formatted dates."
 
     Arguments:
         format => Date format using standard strftime format.
+        tz => Instance of datetime.tzinfo
 
     Example:
         date_format('%b-%y')
         date_format('%B %d, %Y')
     """
-    return DateFormatter(format)
+    return DateFormatter(format,tz)


### PR DESCRIPTION
Included a new argument tz to date_format, with value None by default. 
tz is used as tz argument for DateFormatter, and it must be an instance of datetime.tzinfo

This allows to specify a timezone for the date format.