### PR TITLE
store version only in ggplot package

### DIFF
--- a/ggplot/__init__.py
+++ b/ggplot/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 
 # For testing purposes we might need to set mpl backend before any
 # other import of matplotlib.

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,25 @@
 import os
 from setuptools import find_packages, setup
-from ggplot.__init__ import __version__
 
+
+def extract_version():
+    """Return ggplot.__version__ without importing ggplot.
+    
+    Extracts version from ggplot/__init__.py
+    without importing ggplot, which requires dependencies to be installed.
+    """
+    with open('ggplot/__init__.py') as fd:
+        ns = {}
+        for line in fd:
+            if line.startswith('__version__'):
+                exec(line.strip(), ns)
+                return ns['__version__']
 
 
 setup(
     name="ggplot",
     # Increase the version in ggplot/__init__.py
-    version="0.9.4",
+    version=extract_version(),
     author="Greg Lamp",
     author_email="greg@yhathq.com",
     url="https://github.com/yhat/ggplot/",


### PR DESCRIPTION
This largely reverts 5d2f1b2ebc3647cca919ef49ca5a87924a4c61ee

Effects:

- only one place to store version (ggplot 0.9.4 `__version__` reports itself as 0.9.3)
- avoids importing ggplot in setup, which requires all dependencies,
  which may not be installed yet when setup.py is run to determine what the dependencies are.