### PR TITLE
Python 3 compat tweaks (unicode/str/UserDict)

### DIFF
--- a/ggplot/aes.py
+++ b/ggplot/aes.py
@@ -1,11 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import sys
-if sys.hexversion > 0x03000000:
-    # UserDict moved in python3 standard library
-    from collections import UserDict
-else:
-    from UserDict import UserDict
+
+from six.moves import UserDict
 
 from copy import deepcopy
 

--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -7,6 +7,7 @@ from matplotlib.colors import LinearSegmentedColormap
 
 from patsy.eval import EvalEnvironment
 
+import six
 import numpy as np
 import pandas as pd
 import warnings
@@ -147,7 +148,7 @@ class ggplot(object):
         labels = [(self.fig.suptitle, self.title)] #, (plt.xlabel, self.xlab), (plt.ylabel, self.ylab)]
         for mpl_func, label in labels:
             if label:
-                if isinstance(label, (str, unicode)):
+                if isinstance(label, six.text_types):
                     label = element_text(label)
                 label.override(0.5, 0.95)
                 label.apply_to_fig(self.fig)
@@ -268,7 +269,7 @@ class ggplot(object):
 
 
         if xlab:
-            if isinstance(xlab, (str, unicode)):
+            if isinstance(xlab, six.text_types):
                 xlab = element_text(xlab)
 
             # encofrce it to be an x-label
@@ -280,7 +281,7 @@ class ggplot(object):
         else:
             ylab = self._aes.get('y', '')
 
-        if isinstance(ylab, (str, unicode)):
+        if isinstance(ylab, six.text_types):
             ylab = element_text(ylab)
 
         if ylab:

--- a/ggplot/legend.py
+++ b/ggplot/legend.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 import re
+import six
 
 def tex_escape(text):
     """
@@ -23,7 +24,7 @@ def tex_escape(text):
         '<': r'\textless',
         '>': r'\textgreater',
     }
-    regex = re.compile('|'.join(re.escape(unicode(key)) for key in sorted(conv.keys(), key = lambda item: - len(item))))
+    regex = re.compile('|'.join(re.escape(six.text_type(key)) for key in sorted(conv.keys(), key = lambda item: - len(item))))
     return regex.sub(lambda match: conv[match.group()], text)
 
 def color_legend(color):
@@ -61,7 +62,7 @@ def make_aesthetic_legend(aesthetic, value):
 def make_legend(ax, legend_mapping):
     # TODO: for some reason this reaks havoc! but this is also how you would do a bold legend :(
     # plt.rc('text', usetex=True)
-    
+
     extra = Rectangle((0, 0), 0, 0, facecolor="w", fill=False, edgecolor='none', linewidth=0)
 
     items = []


### PR DESCRIPTION
Fixes #500 and simplifies an explicit version check for UserDict using the magic of `six`