### PR TITLE
Universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
Because the source is 2/3 compatible, this cfg flag will tell `bdist_wheel` to build a universal wheel.

See https://wheel.readthedocs.io/en/latest/#defining-the-python-version