### PR TITLE
Removing contrasting edges in scatter plots by default

### DIFF
--- a/ggplot/geoms/geom_point.py
+++ b/ggplot/geoms/geom_point.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..utils import is_date
 
 class geom_point(geom):
-    DEFAULT_AES = {'alpha': 1, 'color': 'black', 'shape': 'o', 'size': 20, 'edgecolors': None}
+    DEFAULT_AES = {'alpha': 1, 'color': 'black', 'shape': 'o', 'size': 20, 'edgecolors': 'none'}
     REQUIRED_AES = {'x', 'y'}
     _aes_renames = {'size': 's', 'shape': 'marker', 'color': 'c'}
     DEFAULT_PARAMS = {'position': None}


### PR DESCRIPTION
The matplotlib documentation for the `edgecolors` parameter of the
`scatter` method states the following:

> "If None, defaults to (patch.edgecolor). ... If it is ‘none’, the
patch boundary will not be drawn."

The default value is currently `None` which makes all of the points in
a scatter plot show a contrasting edge. This does not match the style
of ggplot2 and has a very "noisy" look. This change switches the
`edgecolors` parameter to `'none'`, which removes the edge completely
makes the plot match ggplot2's look and also reduces visual noise in
the graph.

## Scatter plot before the change:

![before](https://cloud.githubusercontent.com/assets/10200/16706891/8e8ea37c-458b-11e6-972b-4f24bd04e438.png)

## Scatter plot after the change:

![after](https://cloud.githubusercontent.com/assets/10200/16706892/977b016a-458b-11e6-81d5-0219b8f38c08.png)
