### PR TITLE
Fix #517: Apply limits to all facets

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -164,10 +164,11 @@ class ggplot(object):
                 ax.set_title(name, fontdict={'fontsize': 10})
 
     def apply_limits(self):
-        limits = [(plt.xlim, self.xlimits), (plt.ylim, self.ylimits)]
-        for mpl_func, limit in limits:
-            if limit:
-                mpl_func(limit)
+        for ax in self._iterate_subplots():
+            if self.xlimits:
+                ax.set_xlim(self.xlimits)
+            if self.ylimits:
+                ax.set_ylim(self.ylimits)
 
     def apply_scales(self):
         for scale in self.scales:


### PR DESCRIPTION
Fixes https://github.com/yhat/ggplot/issues/517:

```python
(ggplot(diamonds, aes(x='carat')) +
    geom_histogram() +
    ylim(low=-1000) +
    #facet_wrap(x='cut') +               # Good: ylim applies to all facets
    facet_wrap(x='cut', scales='free') + # Fixed: ylim applies to all facets
    geom_blank()
)
```

![image](https://cloud.githubusercontent.com/assets/627486/17352325/a3050dba-58ea-11e6-8fae-3bf30e7ff268.png)

```python
(ggplot(diamonds, aes(x='carat')) +
    geom_histogram() +
    ylim(low=-1000) +
    facet_wrap(x='cut') +                 # Good: ylim applies to all facets
    #facet_wrap(x='cut', scales='free') + # Fixed: ylim applies to all facets
    geom_blank()
)
```

![image](https://cloud.githubusercontent.com/assets/627486/17352326/a51ff27c-58ea-11e6-9ea2-b815265af3c7.png)
