### PR TITLE
boxplot/errorbar/violin: sort Categorical x aesthetics

### DIFF
--- a/ggplot/geoms/geom_boxplot.py
+++ b/ggplot/geoms/geom_boxplot.py
@@ -28,7 +28,6 @@ class geom_boxplot(geom):
     def plot(self, ax, data, _aes, x_levels):
         (data, _aes) = self._update_data(data, _aes)
         params = self._get_plot_args(data, _aes)
-        x_levels = sorted(x_levels)
         variables = _aes.data
         x = data[variables['x']]
         y = data[variables['y']]

--- a/ggplot/geoms/geom_violin.py
+++ b/ggplot/geoms/geom_violin.py
@@ -24,7 +24,6 @@ class geom_violin(geom):
     def plot(self, ax, data, _aes, x_levels):
         (data, _aes) = self._update_data(data, _aes)
         params = self._get_plot_args(data, _aes)
-        x_levels = sorted(x_levels)
         variables = _aes.data
 
         xticks = []

--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -608,7 +608,8 @@ class ggplot(object):
                             layer.plot(ax, facetgroup, self._aes, x_levels=self.data[self._aes['x']].unique(),
                                 fill_levels=fill_levels, lookups=df)
                         elif layer.__class__.__name__ in ("geom_boxplot", "geom_violin", "geom_errorbar"):
-                            layer.plot(ax, facetgroup, self._aes, x_levels=self.data[self._aes['x']].unique())
+                            x_levels = list(pd.Series(self.data[self._aes['x']].unique()).sort_values())
+                            layer.plot(ax, facetgroup, self._aes, x_levels=x_levels)
                         else:
                             layer.plot(ax, facetgroup, self._aes)
 

--- a/tests/test_boxplot.py
+++ b/tests/test_boxplot.py
@@ -1,6 +1,11 @@
 from ggplot import *
+import pandas as pd
 
 
 print ggplot(mpg, aes(x='class', y='hwy')) + geom_boxplot()
 print ggplot(mpg, aes(x='class', y='hwy')) + geom_boxplot() + facet_wrap('manufacturer')
 print ggplot(diamonds, aes('pd.cut(carat, bins=10, labels=range(10))', 'price')) + geom_boxplot()
+
+diamonds['clarity'] = pd.Categorical(diamonds['clarity'], ordered=True,
+                                     categories='I1 SI2 SI1 VS2 VS1 VVS2 VVS1 IF'.split())
+print ggplot(diamonds, aes(x='clarity', y='price')) + geom_boxplot()

--- a/tests/test_violin.py
+++ b/tests/test_violin.py
@@ -1,8 +1,12 @@
 from ggplot import *
+import pandas as pd
 
 p = ggplot(mtcars, aes('factor(cyl)', 'mpg'))
 print p + geom_violin()
 
+diamonds['clarity'] = pd.Categorical(diamonds['clarity'], ordered=True,
+                                     categories='I1 SI2 SI1 VS2 VS1 VVS2 VVS1 IF'.split())
+print ggplot(diamonds, aes(x='clarity', y='price')) + geom_violin()
 
 
 # import matplotlib.pyplot as plt


### PR DESCRIPTION
When the x aesthetic of these geoms refers to an ordered pd.Categorical,
they should sort according to that ordering. Previously they were simply
ordering according to a simple sort of the values.

x.drop_duplicates() might seem more natural than Series(x.unique()). But
I did some testing, and drop_duplicates is considerably (2-10x) slower
in most cases.

(The exceptions were with non-categorical string data: they were about
even with a lot of levels, and drop_duplicates was about 2x *faster*
with only a small number of levels. But with non-categorical numeric
data, or categorical numeric or string data, unique is faster.)