### PR TITLE
Fixed stats_smooth.py to ensure that dataframes with NaN values are r…

### DIFF
--- a/ggplot/stats/stat_smooth.py
+++ b/ggplot/stats/stat_smooth.py
@@ -55,6 +55,8 @@ class stat_smooth(geom):
     def plot(self, ax, data, _aes):
         (data, _aes) = self._update_data(data, _aes)
         variables = _aes.data
+        data = data[list(variables.values())]
+        data = data.dropna()
         x = data[variables['x']]
         y = data[variables['y']]
 


### PR DESCRIPTION
…endered correctly.  Proir to this fix, no fit line was drawn when using the 'lm' method.  Two lines have been added to drop NA values from a filtered version of the dataframe to ensure that all lines are drawn.
