### PR TITLE
Add missing import

### DIFF
--- a/ggplot/themes/theme_538.py
+++ b/ggplot/themes/theme_538.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from .theme import theme_base
+from cycler import cycler
 
 class theme_538(theme_base):
     """


### PR DESCRIPTION
Line 21 fails in the current build, as cycler has not been imported.
This imports cycler.